### PR TITLE
Fix debounce import error

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -2,7 +2,7 @@
 import {CompositeDisposable} from 'atom';
 import {xkcd as _xkcd} from './xkcd';
 import {state, store} from './state';
-import debounce from 'lodash/function/debounce';
+import {debounce} from 'lodash/function';
 import shell from 'shell';
 
 export let xkcdPostViewDisposable = null;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xkcd-comics",
+  "name": "xkcd-fork",
   "main": "./lib/main",
   "version": "0.3.0",
   "description": "xkcd comics",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xkcd-fork",
+  "name": "xkcd-comics",
   "main": "./lib/main",
   "version": "0.3.0",
   "description": "xkcd comics",


### PR DESCRIPTION
Line #5 in lib/view.js did not properly import debounce from lodash's functions
using ES6 syntax. The import has been changed to import the function as a
property of lodash's function object.